### PR TITLE
feat: close stale issues and PRs

### DIFF
--- a/.github/workflows/close-stale-issues-pr.yml
+++ b/.github/workflows/close-stale-issues-pr.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs with 30 days of inactivity'
+on:
+  schedule:
+    - cron : '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5.0.0
+        with:
+          repo-token: ${{ secrets.GHPROJECT_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This pull request was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
Checks every day at 00:00 if there are some inactive issues or PRs since 30 days. If yes, they will be closed automatically after 5 days.